### PR TITLE
add healthcheck to the failover template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 Here is a cloudformation stack that will prevent failover automatic recovery as listed in this aws post
 [How can I prevent failover automatic recovery?](https://forums.aws.amazon.com/thread.jspa?threadID=128432)
 
-This issue has never been resolved and this is just my take to the solution.
+This issue has never been resolved and this is just [our][www.signiant.com] take to the solution.
 
 When properly deployed this aws cloudformation stack will do the following:
 
-1) create a health check for a specific domain specified by the user that notify an alarm on domain failover
+1) create a health check for a specific domain specified by the user that notifies an alarm on domain failover
 2) create the alarm that sends an event to SNS topic on failover
 3) create the SNS topic to receive alarm event
 4) create an SNS Subscription that sends an event from topic to a lambda function
@@ -20,7 +20,7 @@ the `./deploy.sh` script will need the following parameters
 1) s3 bucket to store the lambda function
 2) the profile of aws to be deployed on
 3) the region of the aws to be deployed on
-4) the stack name of the newly created stack
+4) the prefix name (the domain the stack will cover) of the newly created stack (`route53-prevent-switch-primary-${prefix_name}`)
 5) override parameters that are required to specify the region (same as number 3) and domain name (the domain the user want to perform a health check on)
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Here is a cloudformation stack that will prevent failover automatic recovery as listed in this aws post
 [How can I prevent failover automatic recovery?](https://forums.aws.amazon.com/thread.jspa?threadID=128432)
 
-This issue has never been resolved and this is just [our](www.signiant.com) take to the solution.
+This issue has never been resolved and this is just [our](https://www.signiant.com) take to the solution.
 
 When properly deployed this aws cloudformation stack will do the following:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Here is a cloudformation stack that will prevent failover automatic recovery as listed in this aws post
 [How can I prevent failover automatic recovery?](https://forums.aws.amazon.com/thread.jspa?threadID=128432)
 
-This issue has never been resolved and this is just [our][www.signiant.com] take to the solution.
+This issue has never been resolved and this is just [our](www.signiant.com) take to the solution.
 
 When properly deployed this aws cloudformation stack will do the following:
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 
 Here is a cloudformation stack that will prevent failover automatic recovery as listed in this aws post
-https://forums.aws.amazon.com/thread.jspa?threadID=128432
+[How can I prevent failover automatic recovery?](https://forums.aws.amazon.com/thread.jspa?threadID=128432)
 
 This issue has never been resolved and this is just my take to the solution.
 
 When properly deployed this aws cloudformation stack will do the following:
 
-1) create a health check for a specific domain specified by user that notify an alarm on domain failover
-2) create the alarm that send event to SNS topic on failover
-3) create the SNS topic to recieve alarm event
-4) create a SNS Sbscription that send event from topic to a lambda function
+1) create a health check for a specific domain specified by the user that notify an alarm on domain failover
+2) create the alarm that sends an event to SNS topic on failover
+3) create the SNS topic to receive alarm event
+4) create an SNS Subscription that sends an event from topic to a lambda function
 5) create a lambda function that when detect the SNS subscription event will set healthcheck to always fail.
 
 To deploy this cloudformation stack, simply clone the repo locally and run `./deploy.sh [1] [2] [3] [4] [5]`
@@ -21,10 +21,10 @@ the `./deploy.sh` script will need the following parameters
 2) the profile of aws to be deployed on
 3) the region of the aws to be deployed on
 4) the stack name of the newly created stack
-5) override parameters that are required to specify the region (same as number 3) and domain name (the domain the user want to perform health check on)
+5) override parameters that are required to specify the region (same as number 3) and domain name (the domain the user want to perform a health check on)
 
 
-An examples of the `./deploy.sh`:
+An example of the `./deploy.sh`:
 
 ```./deploy.sh dev2-useast1-lambda-deploy dev2 us-east-1  my-domain-check-name "Region=us-east-1 DomainName=test-microservice-domain.com"```
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # platform-circuit-breaker
-when health check fail switch to backup aws s3 server without switching back.
+
+
+Here is a cloudformation stack that will prevent failover automatic recovery as listed in this aws post
+https://forums.aws.amazon.com/thread.jspa?threadID=128432
+
+This issue has never been resolved and this is just my take to the solution.
+
+When properly deployed this aws cloudformation stack will do the following:
+
+1) create a health check for a specific domain specified by user that notify an alarm on domain failover
+2) create the alarm that send event to SNS topic on failover
+3) create the SNS topic to recieve alarm event
+4) create a SNS Sbscription that send event from topic to a lambda function
+5) create a lambda function that when detect the SNS subscription event will set healthcheck to always fail.
+
+To deploy this cloudformation stack, simply clone the repo locally and run `./deploy.sh [1] [2] [3] [4] [5]`
+
+the `./deploy.sh` script will need the following parameters
+1) s3 bucket to store the lambda function
+2) the profile of aws to be deployed on
+3) the region of the aws to be deployed on
+4) the stack name of the newly created stack
+5) override parameters that are required to specify the region (same as number 3) and domain name (the domain the user want to perform health check on)
+
+
+An examples of the `./deploy.sh`:
+
+```./deploy.sh dev2-useast1-lambda-deploy dev2 us-east-1  my-domain-check-name "Region=us-east-1 DomainName=test-microservice-domain.com"```
+
+The above command will execute the stack packing and stack deploy automatically. Take of the closer look of the deploy.sh to see if it matches your need.
+
+
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@
 deploy_bucket=$1
 profile=$2
 region=$3
-domain_name=$4
+prefix_name=$4
 parameters=$5
 
 rm -rf package
@@ -42,7 +42,7 @@ fi
 echo "Deploying lambda..."
 aws cloudformation deploy --capabilities CAPABILITY_IAM  \
     --template-file ./packaged-template.yaml \
-    --stack-name route53-prevent-switch-primary-${domain_name}  \
+    --stack-name route53-prevent-switch-primary-${prefix_name}  \
     --parameter-overrides $parameters \
     --profile $profile  --region $region
 RETCODE=$?

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 
+deploy_bucket=$1
+profile=$2
+region=$3
+parameters=$4
+
 rm -rf package
 
 mkdir package
@@ -12,14 +17,17 @@ cd package
     pip install -r ../requirements.txt --target .
 cd ..
 
-# Package up lambda code
+# Package up lambda code example:
+# --s3-bucket dev2-useast1-lambda-deploy
+# --profile dev2 --region us-east-1
+
 echo "Packaging up lambda for deployment..."
 aws cloudformation package \
     --template-file template.yaml \
-    --s3-bucket dev2-useast1-lambda-deploy \
+    --s3-bucket $deploy_bucket \
     --s3-prefix lambda-healthcheck-editor \
     --output-template-file packaged-template.yaml \
-    --profile dev2
+    --profile $profile --region $region
 RETCODE=$?
 if [ $RETCODE -ne 0 ]; then
     echo "Failed to create package"
@@ -27,8 +35,9 @@ if [ $RETCODE -ne 0 ]; then
 fi
 
 # Deploy the lambda
+# --parameter-overrides Region=us-east-1 DomainName=https://example.com
 echo "Deploying lambda..."
-aws cloudformation deploy     --capabilities CAPABILITY_IAM  --template-file ./packaged-template.yaml  --stack-name route53-disable-healthcheck-on-failover    --parameter-overrides Region=us-east-1 --profile dev2  --region us-east-1
+aws cloudformation deploy --capabilities CAPABILITY_IAM  --template-file ./packaged-template.yaml  --stack-name route53-disable-healthcheck-on-failover  --parameter-overrides $parameters --profile $profile  --region $region
 RETCODE=$?
 if [ $RETCODE -ne 0 ]; then
     echo "Failed to deploy lambda package"

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,8 @@
 deploy_bucket=$1
 profile=$2
 region=$3
-parameters=$4
+domain_name=$4
+parameters=$5
 
 rm -rf package
 
@@ -28,6 +29,7 @@ aws cloudformation package \
     --s3-prefix lambda-healthcheck-editor \
     --output-template-file packaged-template.yaml \
     --profile $profile --region $region
+
 RETCODE=$?
 if [ $RETCODE -ne 0 ]; then
     echo "Failed to create package"
@@ -35,9 +37,14 @@ if [ $RETCODE -ne 0 ]; then
 fi
 
 # Deploy the lambda
+# stack-name route53-prevent-switch-primary-$domain_name domain name could me independence-media-shuttle
 # --parameter-overrides Region=us-east-1 DomainName=https://example.com
 echo "Deploying lambda..."
-aws cloudformation deploy --capabilities CAPABILITY_IAM  --template-file ./packaged-template.yaml  --stack-name route53-disable-healthcheck-on-failover  --parameter-overrides $parameters --profile $profile  --region $region
+aws cloudformation deploy --capabilities CAPABILITY_IAM  \
+    --template-file ./packaged-template.yaml \
+    --stack-name route53-prevent-switch-primary-${domain_name}  \
+    --parameter-overrides $parameters \
+    --profile $profile  --region $region
 RETCODE=$?
 if [ $RETCODE -ne 0 ]; then
     echo "Failed to deploy lambda package"

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
-Description: Lambda function which deletes 'expired' CloudService Stacks
+Description: Lambda function which prevent recovery to primary on failover to secondary for route53 domains
 
 Parameters:
   Region:

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,45 @@ Parameters:
     Type: String
     Default: ""
 
+  DomainName:
+    Type: String
+    Default: ""
+
 Resources:
+
+  myHealthCheck:
+    Type: "AWS::Route53::HealthCheck"
+    Properties:
+      HealthCheckConfig:
+        Port: "443"
+        Type: "HTTPS"
+        ResourcePath: "/healthcheck"
+        FullyQualifiedDomainName: !Ref DomainName
+        RequestInterval: "30"
+        FailureThreshold: "3"
+        EnableSNI: True
+      HealthCheckTags:
+        -
+          Key: Name
+          Value: FailoverHealthCheck
+
+  HealthCheckAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: True
+      AlarmDescription: Healthcheck alarm on route53 failover
+      AlarmActions: [!Ref 'NotificationSNSTopic']
+      MetricName: HealthCheckStatus
+      Namespace: AWS/Route53
+      Statistic: Minimum
+      Period: '60'
+      EvaluationPeriods: '3'
+      Threshold: '1'
+      ComparisonOperator: LessThanThreshold
+      Dimensions:
+      - Name: HealthCheckId
+        Value: !Ref myHealthCheck
+
   NotificationSNSTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -58,9 +96,6 @@ Resources:
           - Action:
             - "route53:*"
             - "route53domains:*"
-            - "cloudfront:ListDistributions"
-            - "elasticloadbalancing:DescribeLoadBalancers"
-            - "elasticbeanstalk:DescribeEnvironments"
             - "sns:ListTopics"
             - "sns:ListSubscriptionsByTopic"
             - "cloudwatch:DescribeAlarms"


### PR DESCRIPTION
update deploy script to let user pick the domain name for healthcheck, region, profile, s3-bucket for the lambda
add health check and with alarm integration to aws template. 
remove some needless rules